### PR TITLE
Add ability for lucode::buildLibrary to add, commit and tag a local git repository (no push to remote)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: lucode
 Type: Package
 Title: PIK Landuse Group Code Manipulation and Analysis Tools
-Version: 2.137.0
-Date: 2018-11-15
+Version: 2.138.0
+Date: 2019-02-11
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("Anastasis", "Giannousakis", email = "giannou@pik-potsdam.de", role = "aut"),
              person("David", "Klein", email = "dklein@pik-potsdam.de", role = "aut"),
@@ -18,4 +18,4 @@ License: BSD_2_clause + file LICENSE
 LazyData: no
 Encoding: UTF-8
 RoxygenNote: 6.1.1
-ValidationKey: 381454500
+ValidationKey: 383514440

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,12 +1,13 @@
 Package: lucode
 Type: Package
 Title: PIK Landuse Group Code Manipulation and Analysis Tools
-Version: 2.136.1
-Date: 2018-11-14
+Version: 2.137.0
+Date: 2018-11-15
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("Anastasis", "Giannousakis", email = "giannou@pik-potsdam.de", role = "aut"),
              person("David", "Klein", email = "dklein@pik-potsdam.de", role = "aut"),
              person("Markus", "Bonsch", role = "aut"),
+             person("Lavinia Baumstark", "Baumstark", email = "baumstark@pik-potsdam.de", role = c("aut")),
              person("Florian", "Humpenoeder", email = "humpenoeder@pik-potsdam.de", role = "ctb"))
 Description: A collection of tools which allow to manipulate and analyze code.
 Suggests: igraph, qgraph, tcltk, lusweave, ggplot2, gtools, devtools, mip, curl, visNetwork
@@ -17,4 +18,4 @@ License: BSD_2_clause + file LICENSE
 LazyData: no
 Encoding: UTF-8
 RoxygenNote: 6.1.1
-ValidationKey: 381272489
+ValidationKey: 381454500

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: lucode
 Type: Package
 Title: PIK Landuse Group Code Manipulation and Analysis Tools
-Version: 2.136.0
-Date: 2018-10-05
+Version: 2.136.1
+Date: 2018-11-14
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("Anastasis", "Giannousakis", email = "giannou@pik-potsdam.de", role = "aut"),
              person("David", "Klein", email = "dklein@pik-potsdam.de", role = "aut"),
@@ -16,5 +16,5 @@ BugReports: https://github.com/pik-piam/lucode/issues
 License: BSD_2_clause + file LICENSE
 LazyData: no
 Encoding: UTF-8
-RoxygenNote: 6.1.0
-ValidationKey: 380400240
+RoxygenNote: 6.1.1
+ValidationKey: 381272489

--- a/R/buildLibrary.R
+++ b/R/buildLibrary.R
@@ -12,7 +12,11 @@
 #' 
 #' @param lib Path to the package
 #' @param cran If cran-like test is needed
+<<<<<<< b6bed8b805685ceec63b89803780a26ca3b65fbb
 #' @param git logical indicating if local git additions, commits and tag updates should be enacted. A push to a remote repository must be done manually by the user.
+=======
+#' @param git logical indicating if local git additions, commits and tag updates should be enacted. A push to a remote repository must be done manually be the user.
+>>>>>>> clean up of code
 #' @param update_type 1 if the update is a major revision, 2 (default) for minor, 3 for patch, 4 only for packages in development stage
 #' @author Anastasis Giannousakis, Jan-Philipp Dietrich, Markus Bonsch
 #' @seealso \code{\link{codeExtract}},\code{\link{readDeclarations}}
@@ -157,21 +161,17 @@ buildLibrary<-function(lib=".",cran=TRUE, git=FALSE, update_type=NULL){
   cat(paste0("* updating from version"), descfile_version, "to version", toString(version), "... OK\n")
   
   ############################################################
-  # Update git tags based on type of update
+  # Update git tags based on type of update (Linux)
   ############################################################
-  
-  # workaround with shell for windows
-  # change validation key back to old definition
-  
   if(OS == "Linux" & git == TRUE){
     cat("* starting git operations... OK\n")
-    cat("* adding and committing to local working copy...")
+    cat("* adding and committing to local repository...")
+    # add and commit local changes from buildLibrary
     system("git add .", ignore.stdout = TRUE)
     system2("git", c("commit -m ", '"type', update_type, 'lucode upgrade"'), stdout = FALSE)
     cat(" OK\n")
     
     cat("* updating tags based on update type...")
-
     if(update_type %in% c(1,2)){
       # create new tag for latest commit
       system(paste0("git tag ", version), ignore.stdout = TRUE)

--- a/R/buildLibrary.R
+++ b/R/buildLibrary.R
@@ -140,7 +140,7 @@ buildLibrary<-function(lib=".",cran=TRUE, git=FALSE, update_type=NULL){
   # Update validation key
   ############################################################
   if(cran) {
-    vkey <- paste("ValidationKey:", as.numeric(gsub(".","",as.character(version),fixed=TRUE))*as.numeric(date))
+    vkey <- paste("ValidationKey:", validationkey(version,date))
   } else {
     vkey <- "ValidationKey: 0"
   }

--- a/R/buildLibrary.R
+++ b/R/buildLibrary.R
@@ -184,7 +184,7 @@ buildLibrary<-function(lib=".",cran=TRUE, git=FALSE, update_type=NULL){
     cat(rep("=", options()$width/2), "\n", sep="")
     # default instructions for pushing to remote
     cat("$ git push -u origin master\n")
-    if(update_type %in% c(0,3,4)){
+    if(update_type %in% c(0,3,4) & last != ""){
       cat(paste0("$ git push --delete origin ", last, "\n"))
     }
     cat("$ git push --tags\n")

--- a/R/buildLibrary.R
+++ b/R/buildLibrary.R
@@ -182,7 +182,7 @@ buildLibrary<-function(lib=".",cran=TRUE, git=FALSE, update_type=NULL){
     cat(rep("=", options()$width/2), "\n", sep="")
     # default instructions for pushing to remote
     cat("$ git push -u origin master\n")
-    if(update_type %in% c(0,3,4)){
+    if(update_type %in% c(0,3,4) & last != ""){
       cat(paste0("$ git push --delete origin ", last, "\n"))
     }
     cat("$ git push --tags\n")

--- a/R/buildLibrary.R
+++ b/R/buildLibrary.R
@@ -20,7 +20,7 @@
 #' 
 #' \dontrun{buildLibrary()}
 #' 
-buildLibrary<-function(lib=".",cran=TRUE, git=FALSE, update_type=NULL){
+buildLibrary<-function(lib=".",cran=TRUE, update_type=NULL){
   OS<-Sys.info()["sysname"]
   thisdir<-getwd()
   if(lib!=".") setwd(lib)
@@ -153,42 +153,23 @@ buildLibrary<-function(lib=".",cran=TRUE, git=FALSE, update_type=NULL){
   # Write the modified description files
   ############################################################
   writeLines(descfile,"DESCRIPTION")
-  cat(paste0("* updating from version"), descfile_version, "to version", toString(version), "... OK\n")
   
   ############################################################
-  # Update git tags based on type of update (Linux)
+  # Verbosity for version information and git commands
   ############################################################
-  if(OS == "Linux" & git == TRUE){
-    cat("* starting git operations... OK\n")
-    cat("* adding and committing to local repository...")
-    # add and commit local changes from buildLibrary
-    system("git add .", ignore.stdout = TRUE)
-    system2("git", c("commit -m ", '"type', update_type, 'lucode upgrade"'), stdout = FALSE)
-    cat(" OK\n")
-    
-    cat("* updating tags based on update type...")
-    if(update_type %in% c(1,2)){
-      # create new tag for latest commit
-      system(paste0("git tag ", version), ignore.stdout = TRUE)
-    } else if(update_type %in% c(0,3,4)){
-      # remove previous tag and push new tag up to latest commit
-      last <- system("tag=$(git tag) && last=$(echo $tag | awk 'END {print $NF}') && echo $last", intern = TRUE)
-      if(last != ""){
-        system("tag=$(git tag) && last=$(echo $tag | awk 'END {print $NF}') && git tag -d $last", ignore.stdout = TRUE)
-      }
-      system(paste0("git tag ", version), ignore.stdout = TRUE)
+  
+  if(update_type != 0){
+    cat(paste0("* updating from version"), descfile_version, "to version", toString(version), "... OK\n")
+    if(file.exists(".git")){
+      cat("* git repository detected... OK\n")
+      cat("* command suggestions for updating your git repository:\n")
+      cat(rep("=", options()$width), "\n", sep="")
+      cat(paste0('adding and committing: $ git add . && git commit -m "type ', update_type, ' lucode upgrade"\n'))
+      cat(paste0("version tagging: $ git tag ", version, "\n"))
+      cat("push commits to github: $ git push <remote> <branch>\n")
+      cat("push new tag to github: $ git push --tags\n")
+      cat(rep("=", options()$width), "\n", sep="")
     }
-    cat(" OK\n")
-    cat("* completed local git tagging, to push updates execute the following (generic) commands:\n")
-    cat(rep("=", options()$width/2), "\n", sep="")
-    # default instructions for pushing to remote
-    cat("$ git push -u origin master\n")
-    if(update_type %in% c(0,3,4) & last != ""){
-      cat(paste0("$ git push --delete origin ", last, "\n"))
-    }
-    cat("$ git push --tags\n")
-    cat(rep("=", options()$width/2), "\n", sep="")
   }
-  # issue: workaround with shell for windows
   cat("done")
 }

--- a/R/buildLibrary.R
+++ b/R/buildLibrary.R
@@ -12,7 +12,7 @@
 #' 
 #' @param lib Path to the package
 #' @param cran If cran-like test is needed
-#' @param git logical indicating if local git additions, commits and tag updates should be enacted. A push to a remote repository must be done manually be the user.
+#' @param git logical indicating if local git additions, commits and tag updates should be enacted. A push to a remote repository must be done manually by the user.
 #' @param update_type 1 if the update is a major revision, 2 (default) for minor, 3 for patch, 4 only for packages in development stage
 #' @author Anastasis Giannousakis, Jan-Philipp Dietrich, Markus Bonsch
 #' @seealso \code{\link{codeExtract}},\code{\link{readDeclarations}}

--- a/R/buildLibrary.R
+++ b/R/buildLibrary.R
@@ -139,7 +139,7 @@ buildLibrary<-function(lib=".",cran=TRUE, git=FALSE, update_type=NULL){
   # Update validation key
   ############################################################
   if(cran) {
-    vkey <- paste("ValidationKey:", as.numeric(gsub(".","",as.character(version),fixed=TRUE))*as.numeric(date))
+    vkey <- paste("ValidationKey:", validationkey(version,date))
   } else {
     vkey <- "ValidationKey: 0"
   }

--- a/R/buildLibrary.R
+++ b/R/buildLibrary.R
@@ -173,6 +173,7 @@ buildLibrary<-function(lib=".",cran=TRUE, git=FALSE, update_type=NULL){
       system(paste0("git tag ", version), ignore.stdout = TRUE)
     } else if(update_type %in% c(0,3,4)){
       # remove previous tag and push new tag up to latest commit
+      last <- system("tag=$(git tag) && last=$(echo $tag | awk 'END {print $NF}') && echo $last", intern = TRUE)
       system("tag=$(git tag) && last=$(echo $tag | awk 'END {print $NF}') && git tag -d $last", ignore.stdout = TRUE)
       system(paste0("git tag ", version), ignore.stdout = TRUE)
     }
@@ -181,6 +182,9 @@ buildLibrary<-function(lib=".",cran=TRUE, git=FALSE, update_type=NULL){
     cat(rep("=", options()$width/2), "\n", sep="")
     # default instructions for pushing to remote
     cat("$ git push -u origin master\n")
+    if(update_type %in% c(0,3,4)){
+      cat(paste0("$ git push --delete origin ", last, "\n"))
+    }
     cat("$ git push --tags\n")
     cat(rep("=", options()$width/2), "\n", sep="")
   }

--- a/R/buildLibrary.R
+++ b/R/buildLibrary.R
@@ -140,7 +140,7 @@ buildLibrary<-function(lib=".",cran=TRUE, git=FALSE, update_type=NULL){
   # Update validation key
   ############################################################
   if(cran) {
-    vkey <- paste("ValidationKey:", validationkey(version,date))
+    vkey <- paste("ValidationKey:", as.numeric(gsub(".","",as.character(version),fixed=TRUE))*as.numeric(date))
   } else {
     vkey <- "ValidationKey: 0"
   }
@@ -157,17 +157,22 @@ buildLibrary<-function(lib=".",cran=TRUE, git=FALSE, update_type=NULL){
   cat(paste0("* updating from version"), descfile_version, "to version", toString(version), "... OK\n")
   
   ############################################################
-  # Update git tags based on type of update (Linux)
+  # Update git tags based on type of update
   ############################################################
+  
+  # workaround with shell for windows
+  # change validation key back to old definition
+  
   if(OS == "Linux" & git == TRUE){
+    a <- system2("git", c("config", "-l"), stdout = TRUE)
     cat("* starting git operations... OK\n")
-    cat("* adding and committing to local repository...")
-    # add and commit local changes from buildLibrary
+    cat("* adding and committing to local working copy...")
     system("git add .", ignore.stdout = TRUE)
     system2("git", c("commit -m ", '"type', update_type, 'lucode upgrade"'), stdout = FALSE)
     cat(" OK\n")
     
     cat("* updating tags based on update type...")
+
     if(update_type %in% c(1,2)){
       # create new tag for latest commit
       system(paste0("git tag ", version), ignore.stdout = TRUE)

--- a/R/buildLibrary.R
+++ b/R/buildLibrary.R
@@ -176,7 +176,6 @@ buildLibrary<-function(lib=".",cran=TRUE, git=FALSE, update_type=NULL){
       if(last != ""){
         system("tag=$(git tag) && last=$(echo $tag | awk 'END {print $NF}') && git tag -d $last", ignore.stdout = TRUE)
       }
-
       system(paste0("git tag ", version), ignore.stdout = TRUE)
     }
     cat(" OK\n")

--- a/R/buildLibrary.R
+++ b/R/buildLibrary.R
@@ -12,11 +12,6 @@
 #' 
 #' @param lib Path to the package
 #' @param cran If cran-like test is needed
-<<<<<<< b6bed8b805685ceec63b89803780a26ca3b65fbb
-#' @param git logical indicating if local git additions, commits and tag updates should be enacted. A push to a remote repository must be done manually by the user.
-=======
-#' @param git logical indicating if local git additions, commits and tag updates should be enacted. A push to a remote repository must be done manually be the user.
->>>>>>> clean up of code
 #' @param update_type 1 if the update is a major revision, 2 (default) for minor, 3 for patch, 4 only for packages in development stage
 #' @author Anastasis Giannousakis, Jan-Philipp Dietrich, Markus Bonsch
 #' @seealso \code{\link{codeExtract}},\code{\link{readDeclarations}}

--- a/R/buildLibrary.R
+++ b/R/buildLibrary.R
@@ -174,7 +174,9 @@ buildLibrary<-function(lib=".",cran=TRUE, git=FALSE, update_type=NULL){
     } else if(update_type %in% c(0,3,4)){
       # remove previous tag and push new tag up to latest commit
       last <- system("tag=$(git tag) && last=$(echo $tag | awk 'END {print $NF}') && echo $last", intern = TRUE)
-      system("tag=$(git tag) && last=$(echo $tag | awk 'END {print $NF}') && git tag -d $last", ignore.stdout = TRUE)
+      if(last != ""){
+        system("tag=$(git tag) && last=$(echo $tag | awk 'END {print $NF}') && git tag -d $last", ignore.stdout = TRUE)
+      }
       system(paste0("git tag ", version), ignore.stdout = TRUE)
     }
     cat(" OK\n")

--- a/R/buildLibrary.R
+++ b/R/buildLibrary.R
@@ -163,7 +163,6 @@ buildLibrary<-function(lib=".",cran=TRUE, git=FALSE, update_type=NULL){
   # change validation key back to old definition
   
   if(OS == "Linux" & git == TRUE){
-    a <- system2("git", c("config", "-l"), stdout = TRUE)
     cat("* starting git operations... OK\n")
     cat("* adding and committing to local working copy...")
     system("git add .", ignore.stdout = TRUE)

--- a/R/buildLibrary.R
+++ b/R/buildLibrary.R
@@ -176,6 +176,7 @@ buildLibrary<-function(lib=".",cran=TRUE, git=FALSE, update_type=NULL){
       if(last != ""){
         system("tag=$(git tag) && last=$(echo $tag | awk 'END {print $NF}') && git tag -d $last", ignore.stdout = TRUE)
       }
+
       system(paste0("git tag ", version), ignore.stdout = TRUE)
     }
     cat(" OK\n")
@@ -183,7 +184,7 @@ buildLibrary<-function(lib=".",cran=TRUE, git=FALSE, update_type=NULL){
     cat(rep("=", options()$width/2), "\n", sep="")
     # default instructions for pushing to remote
     cat("$ git push -u origin master\n")
-    if(update_type %in% c(0,3,4) & last != ""){
+    if(update_type %in% c(0,3,4)){
       cat(paste0("$ git push --delete origin ", last, "\n"))
     }
     cat("$ git push --tags\n")

--- a/R/buildLibrary.R
+++ b/R/buildLibrary.R
@@ -164,7 +164,6 @@ buildLibrary<-function(lib=".",cran=TRUE, git=FALSE, update_type=NULL){
   # change validation key back to old definition
   
   if(OS == "Linux" & git == TRUE){
-    a <- system2("git", c("config", "-l"), stdout = TRUE)
     cat("* starting git operations... OK\n")
     cat("* adding and committing to local working copy...")
     system("git add .", ignore.stdout = TRUE)

--- a/R/updateRepo.R
+++ b/R/updateRepo.R
@@ -49,20 +49,21 @@ updateRepo <- function(path=".", check=TRUE, force_rebuild=FALSE, clean=FALSE, p
   nchar <- max(nchar(dirs))
   update_PACKAGES <- FALSE
   for(d in dirs) {
+    setwd(d)
+    if(dir.exists(".svn")) {
+      if(clean) system("svn revert -Rq .; svn update -q", wait = FALSE)
+      else system("svn update -q", wait=FALSE)
+    }
+    if(dir.exists(".git")) {
+      if(clean) system("git reset --hard HEAD -q; git clean -fxq; git pull -q", wait = FALSE)
+      else system("git pull -q", wait = FALSE)
+    }  
+    setwd("..")
+  }
+  for(d in dirs) {
     fd <- format(d,width=nchar)
     curversion <- tryCatch(ap[d,"Version"],error=function(e)return(0))
     setwd(d)
-    if(dir.exists(".svn")) {
-      if(clean) system("svn revert -Rq .")
-      system("svn update -q")
-    }
-    if(dir.exists(".git")) {
-      if(clean) {
-        system("git reset --hard HEAD -q")
-        system("git clean -fxq")
-      }
-      system("git pull -q")
-    }
     vkey <- validkey()
     if(as.numeric_version(curversion) < as.numeric_version(vkey$version) | force_rebuild) {
       if(vkey$valid | !check | force_rebuild) {

--- a/R/updateRepo.R
+++ b/R/updateRepo.R
@@ -36,7 +36,9 @@ updateRepo <- function(path=".", check=TRUE, force_rebuild=FALSE, clean=FALSE, p
     } 
     writeLines(as.character(Sys.getpid()),pidfile)
   }
-  
+  if(file.exists("/webservice")){
+    Sys.setenv("RSTUDIO_PANDOC"="/usr/local/bin/pandoc")
+  }
   if(dir.exists(".svn")) {
     if(clean) system("svn revert -Rq .")
     system("svn update -q")


### PR DESCRIPTION
Hello folks,

When developing an R package which is also hosted on GitHub, it helps to have a tag on version numbers, so that one can revert to older versions is necessary. Also, users could have a view of how the package has been developing through various releases. 

It would be useful to have such an option directly when running lucode::buildLibrary, since version numbers are already going through the memory. It is also less burdensome to do it in an automated manner instead of manually.

For this, an additional logical called `git` has been added as an input and defaults to FALSE. If TRUE, then the function will additionally add and commit to the local git repo. It will also add respective git tags. 

If the `update_type` variable is 1 or 2, a new tag will be created on top of previous ones. If the `update_type` variable is 0, 3 or 4, then the previous tag will be replaced with the newest tag. The motivation for this is to prevent unnecessary build-up of minor tags. 

Currently, I have only written this part of the function for Linux. If this is deemed to be useful, then I would be happy to also develop it for Windows/Mac.

If you want to test this function on a dummy library, feel free to clone/fork this one: https://github.com/AtreyaSh/bareTest.

Would be happy to receive further feedback :snail: 

Best,

Atreya