### PR TITLE
Remove translation to DOS line in lucode

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: lucode
 Type: Package
 Title: PIK Landuse Group Code Manipulation and Analysis Tools
-Version: 2.148.4
-Date: 2019-10-24
+Version: 3.0.0
+Date: 2019-10-25
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("Anastasis", "Giannousakis", email = "giannou@pik-potsdam.de", role = "aut"),
              person("David", "Klein", email = "dklein@pik-potsdam.de", role = "aut"),
@@ -18,4 +18,4 @@ License: BSD_2_clause + file LICENSE
 LazyData: no
 Encoding: UTF-8
 RoxygenNote: 6.1.1
-ValidationKey: 390858412
+ValidationKey: 5458200

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: lucode
 Type: Package
 Title: PIK Landuse Group Code Manipulation and Analysis Tools
-Version: 2.148.2
-Date: 2019-05-10
+Version: 2.148.4
+Date: 2019-10-24
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("Anastasis", "Giannousakis", email = "giannou@pik-potsdam.de", role = "aut"),
              person("David", "Klein", email = "dklein@pik-potsdam.de", role = "aut"),
@@ -18,4 +18,4 @@ License: BSD_2_clause + file LICENSE
 LazyData: no
 Encoding: UTF-8
 RoxygenNote: 6.1.1
-ValidationKey: 387234532
+ValidationKey: 390858412

--- a/R/manipulateConfig.R
+++ b/R/manipulateConfig.R
@@ -6,7 +6,7 @@
 #' replacement!
 #' 
 #' 
-#' @usage manipulateConfig(configFile, ..., line_endings="win")
+#' @usage manipulateConfig(configFile, ..., line_endings="os")
 #' @param configFile a character string containing the name of the
 #' configuration file, that should be manipulated. Supported file formats are
 #' at the moment "gms", "inc", "cfg" (R-syntax), "php", "opt" and "cmd". Other
@@ -25,7 +25,7 @@
 #' 
 #' 
 #' 
-manipulateConfig<-function (configFile, ..., line_endings="win")
+manipulateConfig<-function (configFile, ..., line_endings="os")
 {
     tmp <- list(...)
     if(length(tmp)==1){

--- a/R/manipulateConfig.R
+++ b/R/manipulateConfig.R
@@ -13,7 +13,6 @@
 #' formats are currently not supported
 #' @param ... Variables, that should be set to new values, e.g. title="test"
 #' for default.cfg or s_max_timesteps=10 for magpie.gms
-#' in the format of the currently used OS.
 #' @author Jan Philipp Dietrich, Markus Bonsch, David Klein
 #' @export
 #' @seealso \code{\link{replace_in_file}},\code{\link{manipulateFile}}

--- a/R/manipulateConfig.R
+++ b/R/manipulateConfig.R
@@ -6,14 +6,13 @@
 #' replacement!
 #' 
 #' 
-#' @usage manipulateConfig(configFile, ..., line_endings="os")
+#' @usage manipulateConfig(configFile, ...)
 #' @param configFile a character string containing the name of the
 #' configuration file, that should be manipulated. Supported file formats are
 #' at the moment "gms", "inc", "cfg" (R-syntax), "php", "opt" and "cmd". Other
 #' formats are currently not supported
 #' @param ... Variables, that should be set to new values, e.g. title="test"
 #' for default.cfg or s_max_timesteps=10 for magpie.gms
-#' @param line_endings "win" for windows line endings or "os" for line endings
 #' in the format of the currently used OS.
 #' @author Jan Philipp Dietrich, Markus Bonsch, David Klein
 #' @export
@@ -25,7 +24,7 @@
 #' 
 #' 
 #' 
-manipulateConfig<-function (configFile, ..., line_endings="os")
+manipulateConfig<-function (configFile, ...)
 {
     tmp <- list(...)
     if(length(tmp)==1){
@@ -73,5 +72,5 @@ manipulateConfig<-function (configFile, ..., line_endings="os")
     else {
         stop(paste("Unknown file type", type))
     }
-    manipulateFile(configFile, m, line_endings=line_endings)
+    manipulateFile(configFile, m)
 }

--- a/R/manipulateFile.R
+++ b/R/manipulateFile.R
@@ -4,14 +4,12 @@
 #' manipulate GAMS sourcecode files.
 #' 
 #' 
-#' @usage manipulateFile(file, manipulations,line_endings="os",...)
+#' @usage manipulateFile(file, manipulations,...)
 #' @param file a connection object or a character string describing the file,
 #' that should be manipulated.
 #' @param manipulations A list of 2 element vectors, containing the search
 #' phrase as first element and the replace term as second element. Regular
 #' expressions in perl syntax (including backreferencing) can be used.
-#' @param line_endings "win" for windows line endings or "os" for line endings
-#' in the format of the currently used OS.
 #' @param ... Further options passed to gsub
 #' @author Jan Philipp Dietrich
 #' @export
@@ -21,13 +19,11 @@
 #' #manipulateFile("example.txt",list(c("bla","blub"),c("a","b")))
 #' 
 #' 
-manipulateFile <- function(file,manipulations,line_endings="os",...) {
+manipulateFile <- function(file,manipulations,...) {
   if(!is.list(manipulations)) manipulations <- list(manipulations)
   f <- readLines(file)
   for(m in manipulations) {
     f <- gsub(m[1],m[2],f,perl=TRUE,...)
   }
-  if (line_endings == "win") {
-    writeLinesDOS(f,file)      
-  } else writeLines(f,file)
+  writeLines(f,file)
 }

--- a/R/manipulateFile.R
+++ b/R/manipulateFile.R
@@ -4,7 +4,7 @@
 #' manipulate GAMS sourcecode files.
 #' 
 #' 
-#' @usage manipulateFile(file, manipulations,line_endings="win",...)
+#' @usage manipulateFile(file, manipulations,line_endings="os",...)
 #' @param file a connection object or a character string describing the file,
 #' that should be manipulated.
 #' @param manipulations A list of 2 element vectors, containing the search
@@ -21,7 +21,7 @@
 #' #manipulateFile("example.txt",list(c("bla","blub"),c("a","b")))
 #' 
 #' 
-manipulateFile <- function(file,manipulations,line_endings="win",...) {
+manipulateFile <- function(file,manipulations,line_endings="os",...) {
   if(!is.list(manipulations)) manipulations <- list(manipulations)
   f <- readLines(file)
   for(m in manipulations) {

--- a/R/module.skeleton.R
+++ b/R/module.skeleton.R
@@ -84,7 +84,7 @@ module.skeleton <- function(number, name, types,modelpath=".", modulepath="modul
   mainfile <- switch(version,
                      "1" = path(module_folder,name,ftype="gms"),
                      "2" = path(module_folder,"module",ftype="gms"))
-  if(!file.exists(mainfile)) writeLinesDOS(mtypes_raw,mainfile)
+  if(!file.exists(mainfile)) writeLines(mtypes_raw,mainfile)
   for(t in types) {
     type_folder <- path(module_folder,t)
     if(!file.exists(type_folder)){
@@ -92,9 +92,9 @@ module.skeleton <- function(number, name, types,modelpath=".", modulepath="modul
       typefile <- switch(version,
                          "1" = path(module_folder,t,ftype="gms"),
                          "2" = path(module_folder,t,"realization",ftype="gms"))
-      if(!file.exists(typefile)) writeLinesDOS(phases_raw,typefile)  
+      if(!file.exists(typefile)) writeLines(phases_raw,typefile)  
       for(phase in phases) {
-        writeLinesDOS("",path(type_folder,phase,ftype="gms"))
+        writeLines("",path(type_folder,phase,ftype="gms"))
       }
     }
   }

--- a/R/removeEOF.R
+++ b/R/removeEOF.R
@@ -22,7 +22,7 @@ for (i in 1:length(all_files)) {
   values <- suppressWarnings(readLines(all_files[i]))
   if (grepl("EOF",values[length(values)])) {
     values[length(values)]<-""
-    writeLinesDOS(values,all_files[i])
+    writeLines(values,all_files[i])
   }
 }
 }

--- a/R/replace_in_file.R
+++ b/R/replace_in_file.R
@@ -23,7 +23,6 @@
 #' @param comment Symbol which is used to indicate a comment in the language
 #' the file is written that should be manipulated. Only relevant if add or
 #' addfile are used.
-#' @param writeLinesDOS Boolean deciding whether DOS line endings should be used
 #' @author Jan Philipp Dietrich
 #' @export
 #' @examples
@@ -31,7 +30,7 @@
 #' replace_in_file("example.txt",c("bla","blub"),"EXAMPLE",add="top",addfile=TRUE)
 #' 
 
-replace_in_file <- function(file, content, subject='CODE',add=FALSE,addfile=FALSE,comment='*',writeLinesDOS=FALSE) {
+replace_in_file <- function(file, content, subject='CODE',add=FALSE,addfile=FALSE,comment='*') {
   start <- paste('#+ R SECTION START \\(',subject,'\\) #+',sep='')
   end   <- paste('#+ R SECTION END \\(',subject,'\\) #+',sep='')
   
@@ -72,8 +71,7 @@ replace_in_file <- function(file, content, subject='CODE',add=FALSE,addfile=FALS
   if(start_row >= end_row) stop("end pattern found before start pattern")
   
   f <- c(f[1:start_row],content,f[end_row:length(f)])
-  if(writeLinesDOS) writeLinesDOS(f,file)
-  else writeLines(f,file)
+  writeLines(f,file)
 }
 
 cpt<-function(recip) {

--- a/R/replace_in_file.R
+++ b/R/replace_in_file.R
@@ -31,7 +31,7 @@
 #' replace_in_file("example.txt",c("bla","blub"),"EXAMPLE",add="top",addfile=TRUE)
 #' 
 
-replace_in_file <- function(file, content, subject='CODE',add=FALSE,addfile=FALSE,comment='*',writeLinesDOS=TRUE) {
+replace_in_file <- function(file, content, subject='CODE',add=FALSE,addfile=FALSE,comment='*',writeLinesDOS=FALSE) {
   start <- paste('#+ R SECTION START \\(',subject,'\\) #+',sep='')
   end   <- paste('#+ R SECTION END \\(',subject,'\\) #+',sep='')
   

--- a/R/singleGAMSfile.R
+++ b/R/singleGAMSfile.R
@@ -88,5 +88,6 @@ singleGAMSfile <- function(modelpath=".",mainfile="main.gms",output="full.gms") 
       warning("Catched a command which could not be translated (",code[i],")")
     }
   }
- writeLinesDOS(code,output)   
+ #writeLinesDOS(code,output)   
+ writeLines(code,output)  
 }

--- a/R/singleGAMSfile.R
+++ b/R/singleGAMSfile.R
@@ -88,6 +88,5 @@ singleGAMSfile <- function(modelpath=".",mainfile="main.gms",output="full.gms") 
       warning("Catched a command which could not be translated (",code[i],")")
     }
   }
- #writeLinesDOS(code,output)   
  writeLines(code,output)  
 }

--- a/R/update_modules_embedding.R
+++ b/R/update_modules_embedding.R
@@ -27,7 +27,7 @@
 #' 
 #' \dontrun{update.modules_embedding()}
 #' 
-update_modules_embedding <- function(modelpath=".",modulepath="modules/",includefile="modules/include.gms",verbose=FALSE, writeLinesDOS=TRUE) {
+update_modules_embedding <- function(modelpath=".",modulepath="modules/",includefile="modules/include.gms",verbose=FALSE, writeLinesDOS=FALSE) {
 
   version <- is.modularGAMS(path=modelpath,modulepath=modulepath,version=TRUE)
   if(version==0) stop("Model does not follow modular structure.")

--- a/R/update_modules_embedding.R
+++ b/R/update_modules_embedding.R
@@ -13,7 +13,6 @@
 #' (relative to main folder)
 #' @param verbose Defines whether additional information should be printed or
 #' not.
-#' @param writeLinesDOS Boolean deciding whether DOS line endings should be used
 #' @note Module phases are automatically detected checking the main code of the
 #' model, but not checking code in modules. If you want to use additional
 #' phases which are only included within a module, you need to specify them
@@ -27,7 +26,7 @@
 #' 
 #' \dontrun{update.modules_embedding()}
 #' 
-update_modules_embedding <- function(modelpath=".",modulepath="modules/",includefile="modules/include.gms",verbose=FALSE, writeLinesDOS=FALSE) {
+update_modules_embedding <- function(modelpath=".",modulepath="modules/",includefile="modules/include.gms",verbose=FALSE) {
 
   version <- is.modularGAMS(path=modelpath,modulepath=modulepath,version=TRUE)
   if(version==0) stop("Model does not follow modular structure.")
@@ -83,7 +82,7 @@ update_modules_embedding <- function(modelpath=".",modulepath="modules/",include
                          "2" = path(".",modulepath,module,"module",ftype="gms"))
     code <- c(code,paste("$include \"",moduleGMSpath,"\"",sep=""))
   }
-  replace_in_file(path(modelpath,includefile),code,subject="MODULES",writeLinesDOS=writeLinesDOS)
+  replace_in_file(path(modelpath,includefile),code,subject="MODULES")
   
   #set links to module types
   for(module in modules) {
@@ -100,7 +99,7 @@ update_modules_embedding <- function(modelpath=".",modulepath="modules/",include
     moduleGMSpath <- switch(version,
                             "1" = path(fullmodulepath,module,module,ftype="gms"),
                             "2" = path(fullmodulepath,module,"module",ftype="gms"))
-    replace_in_file(moduleGMSpath,code,subject="MODULETYPES",writeLinesDOS=writeLinesDOS) 
+    replace_in_file(moduleGMSpath,code,subject="MODULETYPES") 
   }
   
   #set links to different module phases
@@ -119,7 +118,7 @@ update_modules_embedding <- function(modelpath=".",modulepath="modules/",include
       realizationGMSpath <- switch(version,
                                    "1" = path(fullmodulepath,module,t,ftype="gms"),
                                    "2" = path(fullmodulepath,module,t,"realization",ftype="gms"))
-      replace_in_file(realizationGMSpath,code,subject="PHASES",writeLinesDOS=writeLinesDOS)     
+      replace_in_file(realizationGMSpath,code,subject="PHASES")     
     }
   }
 
@@ -138,7 +137,7 @@ update_modules_embedding <- function(modelpath=".",modulepath="modules/",include
     content <- c(content,'','      module2realisation(modules,*) "mapping of modules and active realisations" /')
     content <- c(content,paste0("       ",getModules(fullmodulepath)[,"name"]," . %",getModules(fullmodulepath)[,"name"],"%"))
     content <- c(content,'      /',';')
-    replace_in_file('core/sets.gms',content,"MODULES",comment="***",writeLinesDOS=writeLinesDOS)
+    replace_in_file('core/sets.gms',content,"MODULES",comment="***")
 
 
   ############# ADD MODULE INFO IN SETS  ###################### END ############################################

--- a/R/writeLinesDOS.R
+++ b/R/writeLinesDOS.R
@@ -1,7 +1,0 @@
-writeLinesDOS <- function(text, con = stdout()) {
-  if(Sys.info()['sysname']!="Windows") {
-    writeLines(text,con,sep="\r\n")
-  } else {
-    writeLines(text,con)  
-  }
-}


### PR DESCRIPTION
remove all explizit DOS line writing by switch to writeLines (instead of writeLinesDOS) to use native settings while writing. Remove also all switches, since it is assumed, that we will not have to force DOS line endings ever again.