### PR TITLE
two patches:

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: lucode
 Type: Package
 Title: PIK Landuse Group Code Manipulation and Analysis Tools
-Version: 3.3.2
-Date: 2020-01-23
+Version: 3.3.3
+Date: 2020-02-13
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("Anastasis", "Giannousakis", email = "giannou@pik-potsdam.de", role = "aut"),
              person("David", "Klein", email = "dklein@pik-potsdam.de", role = "aut"),
@@ -18,4 +18,4 @@ License: BSD_2_clause + file LICENSE
 LazyData: no
 Encoding: UTF-8
 RoxygenNote: 7.0.2
-ValidationKey: 6070288
+ValidationKey: 6095565

--- a/R/copy_input.R
+++ b/R/copy_input.R
@@ -45,7 +45,7 @@ copy_input <- function(x, sourcepath, suffix=NULL, move=FALSE) {
     if(move & !(i != length(x) &  (x[i] %in% x[i+1:length(x)]))) {
       file.remove(inputpath)
     }
-    cat("   ",format(x[i],width=nmax)," -> ",outputpath, "\n")
+    cat("   ",format(inputpath,width=nmax)," -> ",outputpath, "\n")
   }
   cat("\n")
 }

--- a/R/readRuntime.R
+++ b/R/readRuntime.R
@@ -25,6 +25,8 @@
 readRuntime <- function(path,plot=FALSE,types=NULL,coupled=FALSE,outfname=NULL) {
   run <- NULL
   runtime <- NULL
+  value <- NULL
+  total <- NULL
   cat("\nReading runtime for",length(path),"runs\n")
   for (d in path) {
     splittedpath <- strsplit(d, "/")[[1]]


### PR DESCRIPTION
the use of dplyr syntax in readRuntime.R prevented a build without warnings. workaround by setting variables to NULL.
copy_input provided the wrong log message, as renaming during copying was not visible in the logfile.