### PR TITLE
added vector support to setScenario

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: lucode
 Type: Package
 Title: PIK Landuse Group Code Manipulation and Analysis Tools
-Version: 3.10.3
-Date: 2020-03-13
+Version: 3.11.0
+Date: 2020-03-20
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("Anastasis", "Giannousakis", email = "giannou@pik-potsdam.de", role = "aut"),
              person("David", "Klein", email = "dklein@pik-potsdam.de", role = "aut"),
@@ -17,5 +17,5 @@ BugReports: https://github.com/pik-piam/lucode/issues
 License: BSD_2_clause + file LICENSE
 LazyData: no
 Encoding: UTF-8
-RoxygenNote: 7.0.2
-ValidationKey: 56890402
+RoxygenNote: 7.1.0
+ValidationKey: 57040510

--- a/R/setScenario.R
+++ b/R/setScenario.R
@@ -42,9 +42,9 @@ setScenario <- function(cfg,scenario,scenario_config="config/scenario_config.csv
         stop("Wrong input format: cfg is neither a list nor a character!")
       }
     }
-    tmp <- read.csv(scenario_config,as.is=TRUE,check.names=FALSE)
+    tmp <- try(read.csv(scenario_config,as.is=TRUE,check.names=FALSE), silent=TRUE)
     #check whether reading the table was succesfull, if not try to read it differently
-    if(all(dimnames(tmp)[[1]]==as.character(1:dim(tmp)[1]))) {
+    if(class(tmp)=="try-error" || all(dimnames(tmp)[[1]]==as.character(1:dim(tmp)[1]))) {
       tmp <- read.csv(scenario_config,as.is=TRUE,sep=";",check.names=FALSE)
       dimnames(tmp)[[1]] <- tmp[,1]
       tmp <- tmp[,-1]
@@ -69,6 +69,7 @@ setScenario <- function(cfg,scenario,scenario_config="config/scenario_config.csv
       if(from!=to & to!=""){
         cat("  Update setting | ",i,":",from, " -> ",to,"\n")
         if(suppressWarnings(!is.na(as.numeric(to)))) to <- as.numeric(to)
+        if(grepl(",",to,fixed=TRUE)) to <- strsplit(to,",")[[1]]
         # finally set the switch
         eval(parse(text=paste0("cfg$",i, "<- to")))
       }   


### PR DESCRIPTION
With this update setScenario will look for commas in the scenario config and separate characters by it, converting a single character to a vector of characters.

@LaviniaBaumstark  @dklein-pik Can you please check whether this is for okay with REMIND? If not, we need another solution to define character vectors in scenario_config